### PR TITLE
📦 chore: alias 설정

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,7 +10,21 @@ module.exports = {
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
-  settings: { react: { version: '18.2' } },
+  settings: {
+    react: { version: '18.2' },
+    'import/resolver': {
+      alias: {
+        map: [
+          ['@', './src'],
+          ['@components', './src/components'],
+          ['@pages', './src/pages'],
+          ['@utils', './src/utils'],
+          ['@images', './src/assets/images'],
+        ],
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+      },
+    },
+  },
   plugins: ['react', 'react-refresh'],
   rules: {
     'react/jsx-no-target-blank': 'off',

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "^8.57.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.34.1",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,17 @@
 import react from '@vitejs/plugin-react';
+import path from 'path';
 import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+      '@components': path.resolve(__dirname, 'src/components'),
+      '@pages': path.resolve(__dirname, 'src/pages'),
+      '@utils': path.resolve(__dirname, 'src/utils'),
+      '@images': path.resolve(__dirname, 'src/assets/images'),
+    },
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,6 +1411,11 @@ eslint-config-airbnb@^19.0.4:
     object.assign "^4.1.2"
     object.entries "^1.1.5"
 
+eslint-import-resolver-alias@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz#297062890e31e4d6651eb5eba9534e1f6e68fc97"
+  integrity sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==
+
 eslint-import-resolver-node@^0.3.9:
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz#d4eaac52b8a2e7c3cd1903eb00f7e053356118ac"


### PR DESCRIPTION
- src, components, pages, utils, image폴더의 alias를 설정하였습니다
- eslint-import-resolver-alias를 사용하여 eslint 문제 해결하였습니다

아이돌 썸네일 만들면서 확인해 보았는데 제 vscode 및 husky + lint-staged에서 문제없이 alias 적용된 것 확인하였습니다.
일단 src폴더, src폴더 내의 components, pages, utils, image만 추가하였습니다.