### PR TITLE
💄  ui: 리스트 페이지의 내 크레딧 스타일링

### DIFF
--- a/src/components/MyCredit.jsx
+++ b/src/components/MyCredit.jsx
@@ -8,7 +8,7 @@ function MyCredit() {
   };
 
   return (
-    <div className="mx-6 flex h-[87px] items-center justify-between rounded-lg border border-whiteGray p-[20px] md:h-[131px] md:px-16 md:py-9 xl:mx-[360px]">
+    <div className="mx-6 flex h-[87px] items-center justify-between rounded-lg border border-whiteGray p-[20px] md:h-[131px] md:px-16 md:py-9 xl:mx-auto xl:max-w-[1200px]">
       <div className="flex flex-col gap-y-2">
         <p className="text-xs text-white opacity-60 md:text-base">내 크레딧</p>
         <div className="flex items-center gap-x-1">

--- a/src/components/MyCredit.jsx
+++ b/src/components/MyCredit.jsx
@@ -10,11 +10,11 @@ function MyCredit() {
   return (
     <div className="mx-6 flex h-[87px] items-center justify-between rounded-lg border border-whiteGray p-[20px] md:h-[131px] md:px-16 md:py-9 xl:mx-[360px]">
       <div className="flex flex-col gap-y-2">
-        <p className="text-xs text-[#FFFFFF99] md:text-base">내 크레딧</p>
+        <p className="text-xs text-white opacity-60 md:text-base">내 크레딧</p>
         <div className="flex items-center gap-x-1">
           <img src={imgCredit} alt="크레딧 이미지" className="size-6" />
           {/* TODO : 크레딧 구현 */}
-          <p className="text-xl font-bold text-[#FFFFFFDE] md:text-2xl">
+          <p className="text-xl font-bold text-white opacity-[0.87] md:text-2xl">
             100,000
           </p>
         </div>

--- a/src/components/MyCredit.jsx
+++ b/src/components/MyCredit.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import imgCredit from '../assets/imgs/ic_credit.svg';
+
+function MyCredit() {
+  const handleClick = () => {
+    console.log('click');
+  };
+
+  return (
+    <div className="mx-6 flex h-[87px] items-center justify-between rounded-lg border border-whiteGray p-[20px] md:h-[131px] md:px-16 md:py-9 xl:mx-[360px]">
+      <div className="flex flex-col gap-y-2">
+        <p className="text-xs text-[#FFFFFF99] md:text-base">내 크레딧</p>
+        <div className="flex items-center gap-x-1">
+          <img src={imgCredit} alt="크레딧 이미지" className="size-6" />
+          {/* TODO : 크레딧 구현 */}
+          <p className="text-xl font-bold text-[#FFFFFFDE] md:text-2xl">
+            100,000
+          </p>
+        </div>
+      </div>
+      <button
+        type="button"
+        className="text-sm font-bold text-pointOrange md:text-base"
+        onClick={handleClick}
+      >
+        충전하기
+      </button>
+    </div>
+  );
+}
+
+export default MyCredit;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,7 @@ export default {
 
         whitePrimary: '#FFF',
         whiteSecondary: '#F7F7F8',
+        whiteGray: '#F1EEF9CC',
 
         pointOrange: '#F96D69',
         pointPink: '#FE5493',


### PR DESCRIPTION
모바일

![image](https://github.com/BestSprinters/i-Konnect/assets/49199024/64df48b0-f19b-4c65-bc9f-49838cd68163)

태블릿

![image](https://github.com/BestSprinters/i-Konnect/assets/49199024/784b1fc3-61b6-468e-b6f8-19e863d9cb69)

PC

![image](https://github.com/BestSprinters/i-Konnect/assets/49199024/3da19b52-f606-4764-9401-680fa9a9508c)

시안에서 아이콘이 16x16px인데 그대로 적용 시키면 너무 작아지는 문제가 있어 24px로 변경하였습니다.
추후에 PC사이즈에서 반응형을 패딩을 제거하고 외부 container 사이즈로 사용해도 괜찮을 것 같습니다.

추가할 사항이나 수정할 사항 있으면 말씀해주세용!