### PR TITLE
🐛 fix: chart 크레딧 충전 시 바로 투표할 수 있게 변경

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useContext } from 'react';
 
 import chartIcon from '../assets/imgs/ic_chart.svg';
+import CreditContext from '../contexts/CreditAmount';
 import useChartLoader from '../hooks/useChartLoader';
 import useMediaQuery from '../hooks/useMediaQuery';
 import useToggle from '../hooks/useToggle';
@@ -11,11 +12,9 @@ import ChoiceGender from './ChoiceGender';
 import VoteModal from './VoteModal';
 
 function Chart() {
+  const { creditAmount, setCreditAmount } = useContext(CreditContext);
   const matches = useMediaQuery('(min-width: 1280px)');
   const { toggle, handleToggle } = useToggle();
-  const [creditAmount, setCreditAmount] = useState(
-    localStorage.getItem('myCredit'),
-  );
   const { chartList, hasMore, updateChartOption, setChartList, chartOption } =
     useChartLoader({
       gender: 'female',


### PR DESCRIPTION
원래는 크레딧이 0일 때, 크레딧을 충전하고 투표 시 새로고침을 해야 투표가 가능 했었는데,
상태 값으로 투표를 하는 대신 usecontext의 값을 이용하는 방식으로 해결했습니다.

https://github.com/BestSprinters/i-Konnect/assets/162538553/513a74ea-f385-4b51-b861-2dc9e8bae172

