### PR TITLE
♻️ refactor: SponsorPagination과 SponsorSlider의 중복 코드 해결

### DIFF
--- a/src/components/SponsorPagination.jsx
+++ b/src/components/SponsorPagination.jsx
@@ -1,107 +1,62 @@
 // swiper eslint 충돌
 
 /* eslint-disable import/no-unresolved */
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import { Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
-import getDonations from '../apis/donations/getDonationsApi';
 import icArrowLeft from '../assets/imgs/ic_arrow_left.svg';
 import icArrowRight from '../assets/imgs/ic_arrow_right.svg';
 import SponsorCard from './SponsorCard';
 
-function SponsorPagination() {
+function SponsorPagination({ donations, onReachEnd }) {
   // 화살표 아이콘 이동을 위한 ref
   const swiperRef = useRef(null);
 
-  const [donationData, setDonationData] = useState([]);
-  const [nextCursor, setNextCursor] = useState('');
-
-  const fetchOption = {
-    cursor: '',
-    pageSize: 10,
-  };
-
-  // 초기 데이터 로딩
-  useEffect(() => {
-    const fetchInitialData = async () => {
-      const initialFetchOption = {
-        cursor: '',
-        pageSize: 10,
-      };
-      try {
-        const result = await getDonations(initialFetchOption);
-        setDonationData(result.list);
-        setNextCursor(result.nextCursor);
-      } catch (error) {
-        console.error('데이터를 불러오지 못했습니다.', error);
-      }
-    };
-
-    fetchInitialData();
-  }, []);
-
-  // 추가 데이터 로딩
-  const handleReachEnd = async () => {
-    if (nextCursor) {
-      try {
-        const newFetchOption = { ...fetchOption, cursor: nextCursor };
-        const result = await getDonations(newFetchOption);
-        setDonationData((prevData) => [...prevData, ...result.list]);
-        setNextCursor(result.nextCursor);
-      } catch (error) {
-        console.error('추가 데이터를 불러오지 못했습니다.', error);
-      }
-    }
-  };
-
   return (
-    <div className="mt-[40px] tablet:mt-[64px]">
-      <h1 className="text-bold text-2xl">후원을 기다리는 조공</h1>
-      <div className="-mx-20 mt-8 flex w-[1360px] items-center justify-center gap-x-10">
-        <button
-          type="button"
-          onClick={() => {
-            swiperRef.current.swiper.slidePrev();
-          }}
-          className="flex h-[80px] w-[40px] items-center justify-center rounded-md bg-grayBlack"
-        >
-          <img
-            src={icArrowLeft}
-            alt="previous arrow"
-            className="h-[20px] w-[10px] cursor-pointer"
-          />
-        </button>
-        <Swiper
-          slidesPerView={4}
-          slidesPerGroup={2}
-          modules={[Navigation]}
-          ref={swiperRef}
-          onReachEnd={handleReachEnd}
-          className="flex w-[1280px] items-center justify-center"
-        >
-          {donationData.map((donation) => (
-            <SwiperSlide key={donation.id}>
-              <SponsorCard donation={donation} />
-            </SwiperSlide>
-          ))}
-        </Swiper>
-        <button
-          type="button"
-          onClick={() => {
-            swiperRef.current.swiper.slideNext();
-          }}
-          className="flex h-[80px] w-[40px] items-center justify-center rounded-md bg-grayBlack"
-        >
-          <img
-            src={icArrowRight}
-            alt="next arrow"
-            className="h-[20px] w-[10px] cursor-pointer"
-          />
-        </button>
-      </div>
+    <div className="-mx-20 mt-8 flex w-[1360px] items-center justify-center gap-x-10">
+      <button
+        type="button"
+        onClick={() => {
+          swiperRef.current.swiper.slidePrev();
+        }}
+        className="flex h-[80px] w-[40px] items-center justify-center rounded-md bg-grayBlack"
+      >
+        <img
+          src={icArrowLeft}
+          alt="previous arrow"
+          className="h-[20px] w-[10px] cursor-pointer"
+        />
+      </button>
+      <Swiper
+        slidesPerView={4}
+        slidesPerGroup={2}
+        modules={[Navigation]}
+        ref={swiperRef}
+        onReachEnd={onReachEnd}
+        className="flex w-[1280px] items-center justify-center"
+      >
+        {donations.map((donation) => (
+          <SwiperSlide key={donation.id}>
+            <SponsorCard donation={donation} />
+          </SwiperSlide>
+        ))}
+      </Swiper>
+      <button
+        type="button"
+        onClick={() => {
+          swiperRef.current.swiper.slideNext();
+        }}
+        className="flex h-[80px] w-[40px] items-center justify-center rounded-md bg-grayBlack"
+      >
+        <img
+          src={icArrowRight}
+          alt="next arrow"
+          className="h-[20px] w-[10px] cursor-pointer"
+        />
+      </button>
     </div>
   );
 }

--- a/src/components/SponsorSlider.jsx
+++ b/src/components/SponsorSlider.jsx
@@ -1,77 +1,29 @@
 // swiper eslint 충돌
 
 /* eslint-disable import/no-unresolved */
-import { useEffect, useState } from 'react';
 import 'swiper/css';
 import 'swiper/css/pagination';
 import { Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
-import getDonations from '../apis/donations/getDonationsApi';
 import SponsorCard from './SponsorCard';
 
-function SponsorSlider() {
-  const [donationData, setDonationData] = useState([]);
-  const [nextCursor, setNextCursor] = useState('');
-
-  const fetchOption = {
-    cursor: '',
-    pageSize: 10,
-  };
-
-  // 초기 데이터 로딩
-  useEffect(() => {
-    const fetchInitialData = async () => {
-      const initialFetchOption = {
-        cursor: '',
-        pageSize: 10,
-      };
-      try {
-        const result = await getDonations(initialFetchOption);
-        setDonationData(result.list);
-        setNextCursor(result.nextCursor);
-      } catch (error) {
-        console.error('데이터를 불러오지 못했습니다.', error);
-      }
-    };
-
-    fetchInitialData();
-  }, []);
-
-  // 추가 데이터 로딩
-  const handleReachEnd = async () => {
-    if (nextCursor) {
-      try {
-        const newFetchOption = { ...fetchOption, cursor: nextCursor };
-        const result = await getDonations(newFetchOption);
-        setDonationData((prevData) => [...prevData, ...result.list]);
-        setNextCursor(result.nextCursor);
-      } catch (error) {
-        console.error('추가 데이터를 불러오지 못했습니다.', error);
-      }
-    }
-  };
-
+function SponsorSlider({ donations, onReachEnd }) {
   return (
-    <div className="mt-10 tablet:mt-16">
-      <h1 className="text-bold mx-6 text-base tablet:text-xl">
-        후원을 기다리는 조공
-      </h1>
-      <div className="mt-4 px-6 tablet:mt-6">
-        <Swiper
-          slidesPerView={3}
-          pagination={{ clickable: true }}
-          modules={[Pagination]}
-          spaceBetween={150}
-          onReachEnd={handleReachEnd}
-        >
-          {donationData.map((donation) => (
-            <SwiperSlide key={donation.id}>
-              <SponsorCard donation={donation} />
-            </SwiperSlide>
-          ))}
-        </Swiper>
-      </div>
+    <div className="mt-4 px-6 tablet:mt-6">
+      <Swiper
+        slidesPerView={3}
+        pagination={{ clickable: true }}
+        modules={[Pagination]}
+        spaceBetween={150}
+        onReachEnd={onReachEnd}
+      >
+        {donations.map((donation) => (
+          <SwiperSlide key={donation.id}>
+            <SponsorCard donation={donation} />
+          </SwiperSlide>
+        ))}
+      </Swiper>
     </div>
   );
 }

--- a/src/pages/ListPage.jsx
+++ b/src/pages/ListPage.jsx
@@ -1,3 +1,6 @@
+import { useEffect, useState } from 'react';
+
+import getDonations from '../apis/donations/getDonationsApi';
 import Chart from '../components/Chart';
 import Header from '../components/Header';
 import MyCredit from '../components/MyCredit';
@@ -8,11 +11,64 @@ import useMediaQuery from '../hooks/useMediaQuery';
 function ListPage() {
   const tabletSize = useMediaQuery('(max-width: 1280px)');
 
+  const [donations, setDonations] = useState([]);
+  const [nextCursor, setNextCursor] = useState('');
+
+  const fetchOption = {
+    cursor: '',
+    pageSize: 10,
+  };
+
+  // 초기 데이터 로딩
+  useEffect(() => {
+    const fetchInitialData = async () => {
+      const initialFetchOption = {
+        cursor: '',
+        pageSize: 10,
+      };
+      try {
+        const result = await getDonations(initialFetchOption);
+        setDonations(result.list);
+        setNextCursor(result.nextCursor);
+      } catch (error) {
+        console.error('데이터를 불러오지 못했습니다.', error);
+      }
+    };
+
+    fetchInitialData();
+  }, []);
+
+  // 추가 데이터 로딩
+  const handleReachEnd = async () => {
+    if (nextCursor) {
+      try {
+        const newFetchOption = { ...fetchOption, cursor: nextCursor };
+        const result = await getDonations(newFetchOption);
+        setDonations((prevData) => [...prevData, ...result.list]);
+        setNextCursor(result.nextCursor);
+      } catch (error) {
+        console.error('추가 데이터를 불러오지 못했습니다.', error);
+      }
+    }
+  };
+
   return (
     <div className="desktop:base-container">
       <Header />
       <MyCredit />
-      {tabletSize ? <SponsorSlider /> : <SponsorPagination />}
+      <div className="mt-10 tablet:mt-16">
+        <h1 className="text-bold mx-6 text-base tablet:text-xl desktop:m-0 desktop:text-2xl">
+          후원을 기다리는 조공
+        </h1>
+        {tabletSize ? (
+          <SponsorSlider donations={donations} onReachEnd={handleReachEnd} />
+        ) : (
+          <SponsorPagination
+            donations={donations}
+            onReachEnd={handleReachEnd}
+          />
+        )}
+      </div>
       <Chart />
     </div>
   );


### PR DESCRIPTION
이슈 번호: #54

`SponsorPagination` 컴포넌트와 `SponsorSlider` 컴포넌트의 중복되는 코드를 상위 컴포넌트인 `ListPage`로 옮겼습니다.

옮긴 중복 코드는 다음과 같습니다.
- donations 상태
- nextCursor 상태
- 초기 데이터 로딩
- 추가 데이터 로딩
- 최상위 div 요소 & "후원을 기다리는 조공" 요소

이제 `SponsorPagination` 컴포넌트와 `SponsorSlider` 컴포넌트는 donations와 onReachEnd만 props로 받아오면 됩니다.

이번 변경사항을 통해 다음과 같은 이점을 얻을 수 있습니다.
- 중복된 코드 제거로 인한 재사용성 증가
- 데이터 로딩을 컴포넌트가 아닌 상위에서 하고 props로 전달하여 불필요한 네트워크 요청 감소

기능적 동작은 바뀌지 않은 단순한 리팩토링입니다.
