### PR TITLE
💄 ui: 나의 크레딧 반응형 크기 수정

### DIFF
--- a/src/components/MyCredit.jsx
+++ b/src/components/MyCredit.jsx
@@ -11,15 +11,13 @@ function MyCredit() {
   const { creditAmount } = useContext(CreditContext);
 
   return (
-    <div className="mx-6 mt-[100px] flex h-[87px] items-center justify-between rounded-lg border border-whiteGray p-[20px] tablet:h-[131px] tablet:px-16 tablet:py-9 desktop:mx-0 desktop:mt-[130px]">
+    <div className="mt-[100px] flex h-[87px] items-center justify-between rounded-lg border border-whiteGray p-[20px] mobile:mx-6 tablet:mx-6">
       <div className="flex flex-col gap-y-2">
-        <p className="text-xs text-white opacity-60 tablet:text-base">
-          내 크레딧
-        </p>
+        <p className="text-xs text-white opacity-60">내 크레딧</p>
         <div className="flex items-center gap-x-1">
           <img src={icCredit} alt="크레딧 이미지" className="size-6" />
           {/* TODO : 크레딧 구현 */}
-          <p className="text-xl font-bold text-white opacity-[0.87] tablet:text-2xl">
+          <p className="text-xl font-bold text-white opacity-[0.87]">
             {formattedNumber(creditAmount)}
           </p>
         </div>


### PR DESCRIPTION
- 나의크레딧 반응형을 pc일 때의 크기를 기준으로 통일
- margin값을 mobile, tablet일 시에 추가해서 세로선?을 일치시킴

desktop
![image](https://github.com/BestSprinters/i-Konnect/assets/162538553/25796457-7f66-4efe-baf5-428792f7bd9e)

tablet
![image](https://github.com/BestSprinters/i-Konnect/assets/162538553/b1cfc8be-c7a8-4766-a984-621dcb5cbf0f)

mobile
![image](https://github.com/BestSprinters/i-Konnect/assets/162538553/c88cded0-7775-4e0b-928a-ddbaec70eb59)
