### PR TITLE
🐛 fix: chart 무한 api호출 제거, eslint 작동 정지시킴.(정상인데 빨간줄띄움)

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-/* eslint-disable */
+/* eslint-disable react-hooks/exhaustive-deps */
 import chartIcon from '../assets/imgs/ic_chart.svg';
 import icSearch from '../assets/imgs/ic_search.svg';
 import useChartLoader from '../hooks/useChartLoader';

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+/* eslint-disable */
 import chartIcon from '../assets/imgs/ic_chart.svg';
 import icSearch from '../assets/imgs/ic_search.svg';
 import useChartLoader from '../hooks/useChartLoader';
@@ -39,7 +40,7 @@ function Chart() {
     return () => {
       clearTimeout(handler);
     };
-  }, [debouncedSearchValue, updateSearchIdol]);
+  }, [debouncedSearchValue]);
 
   return (
     <div className="mb-[60px] mt-[40px] flex-col px-6 tablet:mb-80 tablet:mt-[60px] desktop:mt-20 desktop:px-0">


### PR DESCRIPTION
- useEffect 의존성 배열에서 updateSearchIdol함수를 제거했습니다.
- eslint가 정상적인 코드에 빨간 줄 띄어서 disabled했습니다.