### PR TITLE
🐛 fix: 이달의 차트에서 검색시 덜컹거리는 거 수정

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -77,7 +77,7 @@ function Chart() {
         />
       </div>
       <ChartList chartList={chartList} matches={matches} />
-      {hasMore && (
+      {hasMore ? (
         <div className="mt-8 flex justify-center tablet:mt-7 desktop:mt-12">
           <Button
             type="largeSquareBlack"
@@ -92,6 +92,8 @@ function Chart() {
             더 보기
           </Button>
         </div>
+      ) : (
+        <div className="mt-8 h-[42px] w-[326px] tablet:mt-7 desktop:mt-12" />
       )}
       <VoteModal
         gender={chartOption.gender}

--- a/src/components/ChartList.jsx
+++ b/src/components/ChartList.jsx
@@ -1,9 +1,10 @@
-import React from 'react';
-
 import ChartRank from './ChartRank';
 
 function ChartList({ chartList, matches }) {
   const { length } = chartList;
+  const requiredLength = matches ? 10 : 5;
+  const skeletonCount = requiredLength - length;
+  const skeletonArray = Array.from({ length: skeletonCount });
 
   return (
     <div
@@ -32,6 +33,9 @@ function ChartList({ chartList, matches }) {
           />
         );
       })}
+      {skeletonArray.map((_, key) => (
+        <div key={key && key} className="h-[87px] w-full" />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
- 검색 시 아무 아이돌이 없어도 grid shell 크기를 유지할 수 있도록 배경색과 같은 크기의 `<div/>`들을 추가해줬습니다.
- 더 보기 버튼이 없을 시에도 빈 공간을 `<div/>`로 채워줬습니다.

https://github.com/BestSprinters/i-Konnect/assets/162538553/02dc93de-f2a8-420b-ad46-b7f8f40d8d94

